### PR TITLE
[docs] allow `block.timestamp` >= `parent.timestamp`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,8 @@ The driver directs the L2 node's execution engine to insert new blocks or reorg 
 
 ### Chain synchronization process
 
+> NOTE: The Taiko protocol allows a block's timestamp to be equal to its parent block's timestamp, which differs from the original Ethereum protocol. So it's fine that there are two `TaikoL1.proposeBlock` transactions included in one L1 block.
+
 The driver subscribes to `TaikoL1.BlockProposed` events, and when a new block is proposed:
 
 1. Get the corresponding `TaikoL1.proposeBlock` L1 transaction.


### PR DESCRIPTION
ref: 
- https://github.com/taikochain/taiko-client/pull/21
- https://github.com/taikochain/taiko-mono/pull/195 